### PR TITLE
deps.qt: Add qtcharts and its dependencies

### DIFF
--- a/deps.qt/checksums/qtcharts-everywhere-src-6.4.3.tar.xz.sha256
+++ b/deps.qt/checksums/qtcharts-everywhere-src-6.4.3.tar.xz.sha256
@@ -1,0 +1,1 @@
+4a61e4f5ffb55df69fc58f88255aabca44fb51935b180c03ab81e098d437c346  qtcharts-everywhere-src-6.4.3.tar.xz

--- a/deps.qt/checksums/qtcharts-everywhere-src-6.4.3.zip.sha256
+++ b/deps.qt/checksums/qtcharts-everywhere-src-6.4.3.zip.sha256
@@ -1,0 +1,14 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>Microsoft.PowerShell.Commands.FileHashInfo</T>
+      <T>System.Object</T>
+    </TN>
+    <ToString>Microsoft.PowerShell.Commands.FileHashInfo</ToString>
+    <Props>
+      <S N="Algorithm">SHA256</S>
+      <S N="Hash">2bce1e8abd690037a46f75f8ac9415a38019686360d32039d1c4d3be2c73645a</S>
+      <S N="Path">qtcharts-everywhere-src-6.4.3.zip</S>
+    </Props>
+  </Obj>
+</Objs>

--- a/deps.qt/qt6.ps1
+++ b/deps.qt/qt6.ps1
@@ -12,6 +12,7 @@ $QtComponents = @(
     'qtshadertools'
     'qtmultimedia'
     'qtsvg'
+    'qtcharts'
 )
 
 $Directory = 'qt6'

--- a/deps.qt/qt6.zsh
+++ b/deps.qt/qt6.zsh
@@ -18,6 +18,7 @@ local -a qt_components=(
   'qtshadertools'
   'qtmultimedia'
   'qtsvg'
+  'qtcharts'
 )
 
 local dir='qt6'


### PR DESCRIPTION
This enables building of qtcharts (as well as qtopengl, qtopenglwidgets) on which it depends.